### PR TITLE
Restore Coveralls repo token

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,2 @@
 service_name: travis-ci
+repo_token: NVBaC58Y9y6yx239pAgWl2IJ09sQgx8zp


### PR DESCRIPTION
Because the devs at @lemurheavy can't produce consistent behavior between their docs and their app